### PR TITLE
Remove occurrences of select and join macros

### DIFF
--- a/src/bin/fridge.rs
+++ b/src/bin/fridge.rs
@@ -11,10 +11,7 @@ use futures_concurrency::prelude::*;
 use futures_util::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use signal_hook::consts::SIGHUP;
-use tokio::{
-    join,
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::{IntervalStream, ReceiverStream};
 use tracing::{debug, info, trace};
 use wot_serve::{
@@ -214,7 +211,9 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(handle_messages(fridge, message_receiver, &cli), axum_future);
+    (handle_messages(fridge, message_receiver, &cli), axum_future)
+        .join()
+        .await;
 }
 
 #[derive(Clone)]

--- a/src/bin/on-off-switch-brightness-fade.rs
+++ b/src/bin/on-off-switch-brightness-fade.rs
@@ -1,15 +1,17 @@
 use clap::Parser;
 use demo_things::CliCommon;
+use futures_concurrency::{future::Join, stream::Merge};
+use futures_util::{stream, StreamExt};
 use http_api_problem::HttpApiProblem;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use std::{ops::Not, sync::Arc, time::Duration};
+use std::{future::ready, ops::Not, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use tokio::{
-    join, select,
     sync::{mpsc, oneshot},
     time::sleep,
 };
+use tokio_stream::wrappers::{IntervalStream, ReceiverStream};
 use uuid::Uuid;
 use wot_serve::{
     servient::{BuildServient, HttpRouter, ServientSettings},
@@ -138,10 +140,12 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(
+    (
         handle_messages(thing, message_sender, message_receiver),
-        axum_future
-    );
+        axum_future,
+    )
+        .join()
+        .await;
 }
 
 #[derive(Clone)]
@@ -277,8 +281,14 @@ enum Message {
 async fn handle_messages(
     thing: Thing,
     message_sender: mpsc::Sender<Message>,
-    mut receiver: mpsc::Receiver<Message>,
+    receiver: mpsc::Receiver<Message>,
 ) {
+    enum Event {
+        Message(Message),
+        Tick,
+        Stop,
+    }
+
     let Thing {
         mut is_on,
         mut brightness,
@@ -287,28 +297,28 @@ async fn handle_messages(
     let mut actions = Arc::new(actions);
 
     let mut fader = Fader::default();
-    let mut interval = tokio::time::interval(Duration::from_millis(10));
+    let receiver_stream = ReceiverStream::new(receiver)
+        .map(Event::Message)
+        .chain(stream::once(ready(Event::Stop)));
+    let interval_stream =
+        IntervalStream::new(tokio::time::interval(Duration::from_millis(10))).map(|_| Event::Tick);
 
-    loop {
-        select! {
-            message = receiver.recv() => {
-                match message {
-                    Some(message) => handle_message(
-                        message,
-                        &mut is_on,
-                        &mut brightness,
-                        &mut actions,
-                        &mut fader,
-                        &message_sender,
-                    ).await,
-
-                    None => break,
-                }
+    let mut stream = (receiver_stream, interval_stream).merge();
+    while let Some(event) = stream.next().await {
+        match event {
+            Event::Message(message) => {
+                handle_message(
+                    message,
+                    &mut is_on,
+                    &mut brightness,
+                    &mut actions,
+                    &mut fader,
+                    &message_sender,
+                )
+                .await
             }
-
-            _ = interval.tick() => {
-                fader.tick(&mut brightness);
-            }
+            Event::Tick => fader.tick(&mut brightness),
+            Event::Stop => break,
         }
     }
 }

--- a/src/bin/on-off-switch-brightness-float-fade.rs
+++ b/src/bin/on-off-switch-brightness-float-fade.rs
@@ -1,15 +1,17 @@
 use clap::Parser;
 use demo_things::CliCommon;
+use futures_concurrency::{future::Join, stream::Merge};
+use futures_util::{stream, StreamExt};
 use http_api_problem::HttpApiProblem;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use std::{ops::Not, sync::Arc, time::Duration};
+use std::{future::ready, ops::Not, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use tokio::{
-    join, select,
     sync::{mpsc, oneshot},
     time::sleep,
 };
+use tokio_stream::wrappers::{IntervalStream, ReceiverStream};
 use uuid::Uuid;
 use wot_serve::{
     servient::{BuildServient, HttpRouter, ServientSettings},
@@ -139,10 +141,12 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(
+    (
         handle_messages(thing, message_sender, message_receiver),
-        axum_future
-    );
+        axum_future,
+    )
+        .join()
+        .await;
 }
 
 #[derive(Clone)]
@@ -278,8 +282,14 @@ enum Message {
 async fn handle_messages(
     thing: Thing,
     message_sender: mpsc::Sender<Message>,
-    mut receiver: mpsc::Receiver<Message>,
+    receiver: mpsc::Receiver<Message>,
 ) {
+    enum Event {
+        Message(Message),
+        Tick,
+        Stop,
+    }
+
     let Thing {
         mut is_on,
         mut brightness,
@@ -288,28 +298,28 @@ async fn handle_messages(
     let mut actions = Arc::new(actions);
 
     let mut fader = Fader::default();
-    let mut interval = tokio::time::interval(Duration::from_millis(10));
+    let receiver_stream = ReceiverStream::new(receiver)
+        .map(Event::Message)
+        .chain(stream::once(ready(Event::Stop)));
+    let interval_stream =
+        IntervalStream::new(tokio::time::interval(Duration::from_millis(10))).map(|_| Event::Tick);
 
-    loop {
-        select! {
-            message = receiver.recv() => {
-                match message {
-                    Some(message) => handle_message(
-                        message,
-                        &mut is_on,
-                        &mut brightness,
-                        &mut actions,
-                        &mut fader,
-                        &message_sender,
-                    ).await,
-
-                    None => break,
-                }
+    let mut stream = (receiver_stream, interval_stream).merge();
+    while let Some(event) = stream.next().await {
+        match event {
+            Event::Message(message) => {
+                handle_message(
+                    message,
+                    &mut is_on,
+                    &mut brightness,
+                    &mut actions,
+                    &mut fader,
+                    &message_sender,
+                )
+                .await
             }
-
-            _ = interval.tick() => {
-                fader.tick(&mut brightness);
-            }
+            Event::Tick => fader.tick(&mut brightness),
+            Event::Stop => break,
         }
     }
 }

--- a/src/bin/on-off-switch-brightness-float.rs
+++ b/src/bin/on-off-switch-brightness-float.rs
@@ -1,10 +1,8 @@
 use clap::Parser;
 use demo_things::CliCommon;
+use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    join,
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use wot_serve::{
     servient::{BuildServient, HttpRouter, ServientSettings},
     Servient,
@@ -107,7 +105,9 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(handle_messages(thing, message_receiver), axum_future);
+    (handle_messages(thing, message_receiver), axum_future)
+        .join()
+        .await;
 }
 
 #[derive(Clone)]

--- a/src/bin/on-off-switch-brightness.rs
+++ b/src/bin/on-off-switch-brightness.rs
@@ -1,10 +1,8 @@
 use clap::Parser;
 use demo_things::CliCommon;
+use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    join,
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use wot_serve::{
     servient::{BuildServient, HttpRouter, ServientSettings},
     Servient,
@@ -107,7 +105,9 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(handle_messages(thing, message_receiver), axum_future);
+    (handle_messages(thing, message_receiver), axum_future)
+        .join()
+        .await;
 }
 
 #[derive(Clone)]

--- a/src/bin/on-off-switch-toggle.rs
+++ b/src/bin/on-off-switch-toggle.rs
@@ -1,11 +1,9 @@
 use clap::Parser;
 use demo_things::CliCommon;
+use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
 use std::ops::Not;
-use tokio::{
-    join,
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use wot_serve::{
     servient::{BuildServient, HttpRouter, ServientSettings},
     Servient,
@@ -98,7 +96,9 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(handle_messages(thing, message_receiver), axum_future);
+    (handle_messages(thing, message_receiver), axum_future)
+        .join()
+        .await;
 }
 
 #[derive(Clone)]

--- a/src/bin/on-off-switch.rs
+++ b/src/bin/on-off-switch.rs
@@ -1,10 +1,8 @@
 use clap::Parser;
 use demo_things::CliCommon;
+use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    join,
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use wot_serve::{
     servient::{BuildServient, HttpRouter, ServientSettings},
     Servient,
@@ -86,7 +84,9 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(handle_messages(thing, message_receiver), axum_future);
+    (handle_messages(thing, message_receiver), axum_future)
+        .join()
+        .await;
 }
 
 #[derive(Clone)]

--- a/src/bin/ticking-door.rs
+++ b/src/bin/ticking-door.rs
@@ -1,16 +1,13 @@
 use clap::Parser;
 use demo_things::{config_signal_loader, CliCommon, SimulationStream};
 use door::*;
-use futures_concurrency::stream::Merge;
+use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
 use http_api_problem::HttpApiProblem;
 use serde::{Deserialize, Serialize};
 use signal_hook::consts::SIGHUP;
 use std::{future, path::PathBuf, pin::pin, time::Duration, vec};
-use tokio::{
-    join,
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info};
 use wot_serve::{
@@ -189,7 +186,9 @@ async fn main() {
             .unwrap_or_else(|err| panic!("unable to create web server on address {addr}: {err}"));
     };
 
-    join!(handle_messages(thing, message_receiver, &cli), axum_future);
+    (handle_messages(thing, message_receiver, &cli), axum_future)
+        .join()
+        .await;
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Replacing `select!` with stream composition (through `futures-concurrency`) should make the code more reliable and maintainable.

Replacing `join!` is just a minor nitpick to use `futures-concurrency` homogeneously.