### PR TITLE
Support base field using host from CLI

### DIFF
--- a/src/bin/fridge.rs
+++ b/src/bin/fridge.rs
@@ -6,7 +6,7 @@ use axum::{
     Extension,
 };
 use clap::Parser;
-use demo_things::{config_signal_loader, CliCommon, Simulation, SimulationStream};
+use demo_things::{config_signal_loader, CliCommon, Simulation, SimulationStream, ThingBuilderExt};
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -148,6 +148,7 @@ async fn main() {
         .id("urn:dev:ops:my-fridge-1234")
         .attype("DoorSensor")
         .attype("Thermostat")
+        .base_from_cli(&cli.common)
         .description("A web connected fridge")
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .form(|b| {

--- a/src/bin/lamp.rs
+++ b/src/bin/lamp.rs
@@ -34,7 +34,7 @@ use wot_td::builder::{
 };
 
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 
 struct Lamp {
     is_on: bool,
@@ -72,6 +72,7 @@ async fn main() {
         .id("urn:dev:ops:my-lamp-1234")
         .attype("OnOffSwitch")
         .attype("Light")
+        .base_from_cli(&cli)
         .description("A web connected lamp")
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .form(|b| {

--- a/src/bin/on-off-switch-brightness-fade.rs
+++ b/src/bin/on-off-switch-brightness-fade.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
 use http_api_problem::HttpApiProblem;
@@ -73,6 +73,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/on-off-switch-brightness-float-fade.rs
+++ b/src/bin/on-off-switch-brightness-float-fade.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
 use http_api_problem::HttpApiProblem;
@@ -74,6 +74,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/on-off-switch-brightness-float.rs
+++ b/src/bin/on-off-switch-brightness-float.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
@@ -61,6 +61,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/on-off-switch-brightness.rs
+++ b/src/bin/on-off-switch-brightness.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
@@ -61,6 +61,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/on-off-switch-fade.rs
+++ b/src/bin/on-off-switch-fade.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::stream;
 use http_api_problem::HttpApiProblem;
@@ -76,6 +76,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/on-off-switch-toggle.rs
+++ b/src/bin/on-off-switch-toggle.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
 use std::ops::Not;
@@ -57,6 +57,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/on-off-switch.rs
+++ b/src/bin/on-off-switch.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::future::Join;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
@@ -56,6 +56,7 @@ async fn main() {
         thing_builder = thing_builder.attype("Light");
     }
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("on", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/sink.rs
+++ b/src/bin/sink.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::CliCommon;
+use demo_things::{CliCommon, ThingBuilderExt};
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::stream;
 use serde::{Deserialize, Serialize};
@@ -78,6 +78,7 @@ async fn main() {
         .finish_extend()
         .id("urn:dev:ops:my-sink-1234")
         .attype("OnOffSwitch")
+        .base_from_cli(&cli.common)
         .description("A web connected sink")
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .form(|b| {

--- a/src/bin/ticking-door.rs
+++ b/src/bin/ticking-door.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::{config_signal_loader, CliCommon, SimulationStream};
+use demo_things::{config_signal_loader, CliCommon, SimulationStream, ThingBuilderExt};
 use door::*;
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
@@ -126,6 +126,7 @@ async fn main() {
         .attype("DoorSensor")
         .attype("Lock");
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("open", |b| {
             b.finish_extend_data_schema()

--- a/src/bin/ticking-sensor.rs
+++ b/src/bin/ticking-sensor.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use demo_things::{config_signal_loader, CliCommon, OptionStream};
+use demo_things::{config_signal_loader, CliCommon, OptionStream, ThingBuilderExt};
 use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -135,6 +135,7 @@ async fn main() {
         .attype("TemperatureSensor")
         .attype("HumiditySensor");
     let mut servient = thing_builder
+        .base_from_cli(&cli.common)
         .security(|b| b.no_sec().with_key("nosec_sc").required())
         .property("temperature", |b| {
             b.finish_extend_data_schema()


### PR DESCRIPTION
This should fix #23. @benfrancis sorry for bothering, could you check whether this is sufficient to solve the issue? I added a `--host` CLI param which is then used to fill the `base` field in the WoT description.