### PR TITLE
Fix ambiguous trait with new version of futures-concurrency

### DIFF
--- a/src/bin/fridge.rs
+++ b/src/bin/fridge.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use clap::Parser;
 use demo_things::{config_signal_loader, CliCommon, Simulation, SimulationStream};
-use futures_concurrency::prelude::*;
+use futures_concurrency::{future::Join, stream::Merge};
 use futures_util::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use signal_hook::consts::SIGHUP;


### PR DESCRIPTION
`futures-concurrency` added a `StreamExt` trait in its prelude, which led to an ambiguous `.chain` method for streams.

Avoid using the prelude fixes the issue.