### PR TITLE
Fix collision between light and listen_port CLI arguments

### DIFF
--- a/src/bin/on-off-switch-brightness-fade.rs
+++ b/src/bin/on-off-switch-brightness-fade.rs
@@ -43,7 +43,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 

--- a/src/bin/on-off-switch-brightness-float-fade.rs
+++ b/src/bin/on-off-switch-brightness-float-fade.rs
@@ -44,7 +44,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 

--- a/src/bin/on-off-switch-brightness-float.rs
+++ b/src/bin/on-off-switch-brightness-float.rs
@@ -32,7 +32,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 

--- a/src/bin/on-off-switch-brightness.rs
+++ b/src/bin/on-off-switch-brightness.rs
@@ -32,7 +32,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 

--- a/src/bin/on-off-switch-fade.rs
+++ b/src/bin/on-off-switch-fade.rs
@@ -46,7 +46,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 

--- a/src/bin/on-off-switch-toggle.rs
+++ b/src/bin/on-off-switch-toggle.rs
@@ -31,7 +31,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 

--- a/src/bin/on-off-switch.rs
+++ b/src/bin/on-off-switch.rs
@@ -30,7 +30,7 @@ struct Cli {
     common: CliCommon,
 
     /// Add the Light @type to the switch
-    #[clap(short, long)]
+    #[clap(long)]
     light: bool,
 }
 


### PR DESCRIPTION
This slipped through when I added common CLI arguments for all demos.