### PR TITLE
Don't require a mandatory config

### DIFF
--- a/src/bin/on-off-switch-brightness-fade.rs
+++ b/src/bin/on-off-switch-brightness-fade.rs
@@ -55,7 +55,7 @@ async fn main() {
     let thing = Thing {
         is_on: true,
         brightness: 50,
-        actions: Default::default(),
+        actions: Vec::default(),
     };
 
     let (message_sender, message_receiver) = mpsc::channel(MESSAGE_QUEUE_LENGTH);
@@ -175,15 +175,15 @@ enum StoredActionType {
 }
 
 impl StoredActionType {
-    fn to_fade_mut(&mut self) -> Option<&mut ActionStatus<FadeActionInput>> {
+    fn to_fade_mut(&mut self) -> &mut ActionStatus<FadeActionInput> {
         match self {
-            Self::Fade(fade) => Some(fade),
+            Self::Fade(fade) => fade,
         }
     }
 
-    fn into_output_href(self) -> Option<(Option<FadeActionInput>, Option<String>)> {
+    fn into_output_href(self) -> (Option<FadeActionInput>, Option<String>) {
         match self {
-            Self::Fade(ActionStatus { output, href, .. }) => Some((output, href)),
+            Self::Fade(ActionStatus { output, href, .. }) => (output, href),
         }
     }
 }
@@ -320,8 +320,7 @@ async fn handle_messages(
                     &mut actions,
                     &mut fader,
                     &message_sender,
-                )
-                .await
+                );
             }
             Event::Tick => fader.tick(&mut brightness),
             Event::Stop => break,
@@ -329,7 +328,7 @@ async fn handle_messages(
     }
 }
 
-async fn handle_message(
+fn handle_message(
     message: Message,
     is_on: &mut bool,
     brightness: &mut u8,
@@ -337,7 +336,7 @@ async fn handle_message(
     fader: &mut Fader,
     message_sender: &mpsc::Sender<Message>,
 ) {
-    use Message::*;
+    use Message::{CompleteAction, Fade, GetBrightness, GetIsOn, SetBrightness, SetIsOn};
 
     match message {
         GetIsOn(sender) => sender.send(*is_on).unwrap(),
@@ -355,7 +354,7 @@ async fn handle_message(
             let real_duration = duration
                 .saturating_sub((now - time_requested).try_into().unwrap_or(Duration::ZERO));
             let id = Uuid::new_v4();
-            let href = format!("/actions/fade/{}", id);
+            let href = format!("/actions/fade/{id}");
             let fade_action = ActionStatus {
                 output: Some(FadeActionInput {
                     level: fade_level,
@@ -398,15 +397,12 @@ async fn handle_message(
         }
         CompleteAction(id) => {
             let actions = Arc::make_mut(actions);
-            let action = match actions.iter_mut().find(|action| action.id == id) {
-                Some(action) => action,
-                None => {
-                    tracing::warn!("unable to complete action with id {id}");
-                    return;
-                }
+            let Some(action) = actions.iter_mut().find(|action| action.id == id) else {
+                tracing::warn!("unable to complete action with id {id}");
+                return;
             };
 
-            let action = action.ty.to_fade_mut().unwrap();
+            let action = action.ty.to_fade_mut();
             let now = OffsetDateTime::now_utc();
             action.time_ended = Some(now);
             action.status = ActionStatusStatus::Completed;
@@ -470,7 +466,7 @@ async fn post_fade_action(
     Json(input): Json<FadeActionInput>,
 ) -> impl IntoResponse {
     let action = state.fade(input).await;
-    let (output, href) = action.ty.into_output_href().unwrap();
+    let (output, href) = action.ty.into_output_href();
 
     let response = ActionStatus {
         status: ActionStatusStatus::Pending,

--- a/src/bin/on-off-switch-brightness-float.rs
+++ b/src/bin/on-off-switch-brightness-float.rs
@@ -176,12 +176,12 @@ async fn handle_messages(thing: Thing, mut receiver: mpsc::Receiver<Message>) {
     } = thing;
 
     while let Some(message) = receiver.recv().await {
-        handle_message(message, &mut is_on, &mut brightness).await
+        handle_message(message, &mut is_on, &mut brightness);
     }
 }
 
-async fn handle_message(message: Message, is_on: &mut bool, brightness: &mut f64) {
-    use Message::*;
+fn handle_message(message: Message, is_on: &mut bool, brightness: &mut f64) {
+    use Message::{GetBrightness, GetIsOn, SetBrightness, SetIsOn};
 
     match message {
         GetIsOn(sender) => sender.send(*is_on).unwrap(),

--- a/src/bin/on-off-switch-brightness.rs
+++ b/src/bin/on-off-switch-brightness.rs
@@ -176,12 +176,12 @@ async fn handle_messages(thing: Thing, mut receiver: mpsc::Receiver<Message>) {
     } = thing;
 
     while let Some(message) = receiver.recv().await {
-        handle_message(message, &mut is_on, &mut brightness).await
+        handle_message(message, &mut is_on, &mut brightness);
     }
 }
 
-async fn handle_message(message: Message, is_on: &mut bool, brightness: &mut u8) {
-    use Message::*;
+fn handle_message(message: Message, is_on: &mut bool, brightness: &mut u8) {
+    use Message::{GetBrightness, GetIsOn, SetBrightness, SetIsOn};
 
     match message {
         GetIsOn(sender) => sender.send(*is_on).unwrap(),

--- a/src/bin/on-off-switch-toggle.rs
+++ b/src/bin/on-off-switch-toggle.rs
@@ -158,12 +158,12 @@ async fn handle_messages(thing: Thing, mut receiver: mpsc::Receiver<Message>) {
     let Thing { mut is_on } = thing;
 
     while let Some(message) = receiver.recv().await {
-        handle_message(message, &mut is_on).await
+        handle_message(message, &mut is_on);
     }
 }
 
-async fn handle_message(message: Message, is_on: &mut bool) {
-    use Message::*;
+fn handle_message(message: Message, is_on: &mut bool) {
+    use Message::{GetIsOn, SetIsOn, Toggle};
 
     match message {
         GetIsOn(sender) => sender.send(*is_on).unwrap(),

--- a/src/bin/on-off-switch.rs
+++ b/src/bin/on-off-switch.rs
@@ -140,12 +140,12 @@ async fn handle_messages(thing: Thing, mut receiver: mpsc::Receiver<Message>) {
     let Thing { mut is_on } = thing;
 
     while let Some(message) = receiver.recv().await {
-        handle_message(message, &mut is_on).await
+        handle_message(message, &mut is_on);
     }
 }
 
-async fn handle_message(message: Message, is_on: &mut bool) {
-    use Message::*;
+fn handle_message(message: Message, is_on: &mut bool) {
+    use Message::{GetIsOn, SetIsOn};
 
     match message {
         GetIsOn(sender) => sender.send(*is_on).unwrap(),

--- a/src/bin/oven.rs
+++ b/src/bin/oven.rs
@@ -385,8 +385,7 @@ async fn handle_messages(oven: Oven, receiver: mpsc::Receiver<Message>, cli: &Cl
                         status.temperature,
                         &mut status.target_temperature,
                         &mut status.on,
-                    )
-                    .await
+                    );
                 }
                 Event::Tick => handle_tick(
                     status.open,
@@ -493,14 +492,17 @@ fn handle_tick(
     *temperature = final_temperature;
 }
 
-async fn handle_message(
+fn handle_message(
     message: Message,
     door_is_open: &mut bool,
     temperature: f32,
     target_temperature: &mut u8,
     is_on: &mut bool,
 ) {
-    use Message::*;
+    use Message::{
+        GetIsOn, GetOpen, GetProperties, GetTargetTemperature, GetTemperature, SetIsOn,
+        SetTargetTemperature,
+    };
 
     match message {
         GetProperties(sender) => {

--- a/src/bin/ticking-sensor.rs
+++ b/src/bin/ticking-sensor.rs
@@ -53,7 +53,7 @@ struct SensorConfig {
     variations: Vec<SensorVariation>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 struct SensorVariation {
     #[serde(with = "humantime_serde")]
     duration: Duration,
@@ -271,7 +271,7 @@ async fn handle_messages(thing: Thing, receiver: mpsc::Receiver<Message>, cli: &
 
             match event {
                 Event::Message(message) => {
-                    handle_message(message, temperature.current, humidity.current).await
+                    handle_message(message, temperature.current, humidity.current);
                 }
                 Event::Tick => {
                     let temperature_ticked = temperature.tick();
@@ -327,7 +327,7 @@ impl SensorStatus {
                         self.interpolation = self
                             .variations
                             .next()
-                            .map(|variation| interpolation_from_variation(self.current, variation))
+                            .map(|variation| interpolation_from_variation(self.current, variation));
                     }
                 },
                 None => break false,
@@ -397,8 +397,8 @@ impl Interpolation {
     }
 }
 
-async fn handle_message(message: Message, temperature: f32, humidity: f32) {
-    use Message::*;
+fn handle_message(message: Message, temperature: f32, humidity: f32) {
+    use Message::{GetHumidity, GetTemperature};
 
     match message {
         GetTemperature(sender) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,10 @@ impl CliCommon {
             .or_else(|_| EnvFilter::try_new(filter))
             .unwrap();
 
-        tracing_subscriber::fmt().with_env_filter(filter).init()
+        tracing_subscriber::fmt().with_env_filter(filter).init();
     }
 
+    #[must_use]
     pub fn socket_addr(&self) -> SocketAddr {
         SocketAddr::from((self.bind_addr, self.listen_port))
     }
@@ -96,6 +97,7 @@ impl CliCommon {
 }
 
 pub trait ThingBuilderExt {
+    #[must_use]
     fn base_from_cli(self, cli: &CliCommon) -> Self;
 }
 
@@ -261,6 +263,8 @@ impl<T> ConfigSignalLoaderStreamInner<T> {
 }
 
 pin_project! {
+    // Reason: unsafety is completely handled by pin_project
+    #[allow(clippy::unsafe_derive_deserialize)]
     #[derive(
         Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
     )]
@@ -271,6 +275,8 @@ pin_project! {
 }
 
 pin_project! {
+    // Reason: unsafety is completely handled by pin_project
+    #[allow(clippy::unsafe_derive_deserialize)]
     #[derive(
         Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
     )]


### PR DESCRIPTION
Instead, the default config is used when not specified. It is the same config used with the `--dump` argument, furthermore the user is suggested to dump and use the config file.